### PR TITLE
Refactor `swap` in `local-db-insert-url-into-db`

### DIFF
--- a/src/dpgurl/db.clj
+++ b/src/dpgurl/db.clj
@@ -13,9 +13,7 @@
     long-url))
 
 (defn- local-db-insert-url-into-db [short long]
-    (swap!
-     db
-     #(assoc %1 short long)))
+  (swap! db assoc short long))
 
 ;; Redis db
 ;; uses carmine https://github.com/ptaoussanis/carmine


### PR DESCRIPTION
Hello! I saw your post in /r/Clojure and I want to thank you for posting it. I, as a Clojure newbie, found your little project interesting, it's an opportunity for a lot of people starting with the language to learn, and for you to learn from the community too.

This change I'm proposing is because the `swap!` function call can be shorter and simpler; you pass a function that takes an argument an call `assoc` to create/modify a value; well, the `swap!` function already does that for you: it passes the current value of the atom to the function you supply as an argument, with optional arguments that are passed to the function as well.  Here's an example:

```clj
(def db (atom {}))
; => #'user/db
(swap! db assoc :x 1) ; `assoc` will get the current value of `db` and `:x` and `1` as the rest of the parameters.
; => {:x 1}
@db ; the value is {:x 1}
```

I hope this helps and thank you again for sharing your project!